### PR TITLE
Fixed the Backend struct field tags

### DIFF
--- a/server.go
+++ b/server.go
@@ -27,8 +27,8 @@ type Options struct {
 }
 
 type Backend struct {
-	Addr           string `"yaml:addr"`
-	ConnectTimeout int    `yaml:connect_timeout"`
+	Addr           string `yaml:"addr"`
+	ConnectTimeout int    `yaml:"connect_timeout"`
 }
 
 type Frontend struct {


### PR DESCRIPTION
The messed quotes caused the connect_timeout to be incorrectly parsed and ultimately always set to 0